### PR TITLE
Fix #1, #6, #3: --version literal, yargs in scripts, homebrew auto-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,3 +150,53 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag -f "$MAJOR" "$GITHUB_SHA"
           git push origin "$MAJOR" --force
+
+  # Auto-bump oomfiecity/homebrew-tap's Formula/fmrules.rb on every real
+  # release tag (vX.Y.Z). Skipped on prerelease push-built tags
+  # (v4.0.2-main.…) since `is_tag` is only true on tag pushes.
+  #
+  # Requires the HOMEBREW_TAP_TOKEN secret (fine-grained PAT, contents:write
+  # on oomfiecity/homebrew-tap). Without the secret the second checkout
+  # fails 401 — the rest of the release pipeline is unaffected.
+  bump-homebrew:
+    needs: [version, build, release]
+    if: needs.version.outputs.is_tag == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-*
+          merge-multiple: true
+          path: dist
+      - name: Combine checksums
+        run: |
+          set -euo pipefail
+          cat dist/SHA256SUMS-*.txt > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+      - uses: actions/checkout@v4
+        with:
+          repository: oomfiecity/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+      - name: Render formula
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: bun scripts/render-homebrew-formula.ts SHA256SUMS.txt "$VERSION" > tap/Formula/fmrules.rb
+      - name: Commit + push
+        working-directory: tap
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "Formula already at $VERSION; nothing to do."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am "Bump fmrules to $VERSION"
+          git push origin main

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -6,6 +6,12 @@ const target = Bun.argv[2] ?? "";
 const outfile = Bun.argv[3] ?? "dist/fmrules";
 mkdirSync(dirname(resolve(outfile)), { recursive: true });
 
+// Stamp the package.json `version` into the bundle so `fmrules --version`
+// returns a literal — independent of yargs's filesystem-based pkgUp lookup,
+// which is fragile inside a Bun-compiled VFS.
+const fmrulesPkgPath = Bun.fileURLToPath(new URL("../package.json", import.meta.url));
+const fmrulesPkg = JSON.parse(readFileSync(fmrulesPkgPath, "utf8")) as { version: string };
+
 const playwrightPkgPath = Bun.fileURLToPath(new URL(import.meta.resolve("playwright-core/package.json")));
 const playwrightPkgJson = JSON.parse(readFileSync(playwrightPkgPath, "utf8"));
 const playwrightPkgDir = dirname(playwrightPkgPath);
@@ -47,6 +53,9 @@ const buildArgs: Parameters<typeof Bun.build>[0] = {
   sourcemap: "linked",
   external: ["electron", "chromium-bidi"],
   plugins: [patchPlaywrightPlugin],
+  define: {
+    __FMRULES_VERSION__: JSON.stringify(fmrulesPkg.version),
+  },
 };
 
 if (process.env.BUILD_DEBUG) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,9 +1,35 @@
 #!/usr/bin/env bun
 import { resolve, dirname } from "node:path";
 import { readFileSync, mkdirSync } from "node:fs";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
-const target = Bun.argv[2] ?? "";
-const outfile = Bun.argv[3] ?? "dist/fmrules";
+const argv = await yargs(hideBin(Bun.argv))
+  .scriptName("build")
+  .usage("$0 [target] [outfile]")
+  .command(
+    "$0 [target] [outfile]",
+    "Compile dist/fmrules (or a cross-target binary) via Bun.build",
+    (y) =>
+      y
+        .positional("target", {
+          type: "string",
+          default: "",
+          describe: "Bun cross-compile target (e.g. bun-linux-x64); omit for the host target",
+        })
+        .positional("outfile", {
+          type: "string",
+          default: "dist/fmrules",
+          describe: "Output binary path",
+        }),
+  )
+  .strict()
+  .help()
+  .alias("help", "h")
+  .parseAsync();
+
+const target = argv.target as string;
+const outfile = argv.outfile as string;
 mkdirSync(dirname(resolve(outfile)), { recursive: true });
 
 // Stamp the package.json `version` into the bundle so `fmrules --version`

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -74,46 +74,75 @@ async function runInherit(cmd: string[]): Promise<number> {
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // ──────────────────────────────────────────────────────────────────────
-// Arg parsing
+// Arg parsing — yargs
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 interface Args {
   version?: string;
   bump?: 'patch' | 'minor' | 'major';
   dryRun: boolean;
   skipVerify: boolean;
-  help: boolean;
 }
 
-function parseArgs(argv: string[]): Args {
-  const out: Args = { dryRun: false, skipVerify: false, help: false };
-  for (const a of argv) {
-    if (a === '--help' || a === '-h') out.help = true;
-    else if (a === '--dry-run') out.dryRun = true;
-    else if (a === '--skip-verify') out.skipVerify = true;
-    else if (a === '--patch') out.bump = 'patch';
-    else if (a === '--minor') out.bump = 'minor';
-    else if (a === '--major') out.bump = 'major';
-    else if (!a.startsWith('-')) out.version = a;
-    else fail(`unknown flag: ${a}`, 'run with --help');
-  }
-  return out;
-}
-
-const USAGE = `Usage:
-  bun release <X.Y.Z>           Cut a specific version.
-  bun release --patch           Bump package.json patch; derive version.
-  bun release --minor           Bump package.json minor.
-  bun release --major           Bump package.json major.
-
-Flags:
-  --dry-run       Print the plan without touching state. Preflight still runs.
-  --skip-verify   Push + tag, but skip the post-push CI watch + asset verify.
-  --help, -h      This text.
-
-The script refuses to run if the working tree is dirty, main is out of
+const EPILOGUE = `The script refuses to run if the working tree is dirty, main is out of
 sync with origin, local ci (typecheck + tests) fails, the requested
-tag already exists, or the version arg is malformed. No destructive git
-is ever invoked.`;
+tag already exists, or the version arg is malformed. No destructive
+git is ever invoked.`;
+
+async function parseArgs(rawArgv: string[]): Promise<Args> {
+  const parsed = await yargs(rawArgv)
+    .scriptName('release')
+    .usage('$0 <version> [flags]\n  $0 (--patch|--minor|--major) [flags]')
+    .command(
+      '$0 [version]',
+      'Cut an oomfiecity/fmrules release.',
+      (y) =>
+        y
+          .positional('version', {
+            type: 'string',
+            describe: 'Target version (X.Y.Z or vX.Y.Z). Mutually exclusive with --patch/--minor/--major.',
+          })
+          // Boolean flags are intentionally undefined-by-default so that
+          // yargs `.conflicts()` only fires when the user explicitly
+          // passes a flag. Treat absence as `false` downstream.
+          .option('patch', { type: 'boolean', describe: 'Bump package.json patch and derive version' })
+          .option('minor', { type: 'boolean', describe: 'Bump package.json minor and derive version' })
+          .option('major', { type: 'boolean', describe: 'Bump package.json major and derive version' })
+          .option('dry-run', { type: 'boolean', describe: 'Print the plan without touching state. Preflight still runs.' })
+          .option('skip-verify', { type: 'boolean', describe: 'Push + tag, but skip the post-push CI watch + asset verify.' })
+          .conflicts('patch', ['minor', 'major', 'version'])
+          .conflicts('minor', ['major', 'version'])
+          .conflicts('major', ['version'])
+          .check((a) => {
+            if (!a.version && !a.patch && !a.minor && !a.major) {
+              throw new Error('one of <version> | --patch | --minor | --major is required');
+            }
+            return true;
+          }),
+    )
+    .strict()
+    .help()
+    .alias('help', 'h')
+    // Disable yargs's built-in --version so it doesn't shadow our `version`
+    // positional. The script doesn't have a meaningful "release.ts version"
+    // to report — it operates on the package.json version of the repo.
+    .version(false)
+    .epilogue(EPILOGUE)
+    .parseAsync();
+  const bump =
+    parsed.patch ? 'patch' :
+    parsed.minor ? 'minor' :
+    parsed.major ? 'major' :
+    undefined;
+  return {
+    version: parsed.version as string | undefined,
+    bump,
+    dryRun: parsed['dry-run'] === true,
+    skipVerify: parsed['skip-verify'] === true,
+  };
+}
 
 // ──────────────────────────────────────────────────────────────────────
 // Version utilities
@@ -342,11 +371,7 @@ async function verifySmokeAfter(): Promise<void> {
 // ──────────────────────────────────────────────────────────────────────
 // Driver (top-level await; Bun supports ESM modules directly)
 
-const args = parseArgs(Bun.argv.slice(2));
-if (args.help) {
-  console.log(USAGE);
-  process.exit(0);
-}
+const args = await parseArgs(hideBin(Bun.argv));
 
 // Resolve target version.
 let version: string;
@@ -366,7 +391,7 @@ if (args.version) {
   }
   version = formatVersion(next);
 } else {
-  console.error(USAGE);
+  // parseArgs's .check() rejects this, but TS doesn't know that.
   fail('no version specified');
 }
 const tag = `v${version}`;

--- a/scripts/render-homebrew-formula.ts
+++ b/scripts/render-homebrew-formula.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+/**
+ * Render oomfiecity/homebrew-tap/Formula/fmrules.rb from the SHA256SUMS
+ * file produced by the release workflow.
+ *
+ * Invoked from .github/workflows/release.yml's bump-homebrew job:
+ *   bun run scripts/render-homebrew-formula.ts <SHA256SUMS path> <vX.Y.Z>
+ *     > tap/Formula/fmrules.rb
+ *
+ * Output is stable: same SHAs + same version → byte-identical formula.
+ * The release workflow short-circuits the push when `git diff --quiet`
+ * reports no change, so a re-run on the same release is idempotent.
+ */
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { readFileSync } from 'node:fs';
+
+interface Args {
+  sumsFile: string;
+  version: string;
+}
+
+const argv = await yargs(hideBin(Bun.argv))
+  .scriptName('render-homebrew-formula')
+  .usage('$0 <sumsFile> <version>')
+  .command(
+    '$0 <sumsFile> <version>',
+    'Render Formula/fmrules.rb to stdout',
+    (y) =>
+      y
+        .positional('sumsFile', {
+          type: 'string',
+          demandOption: true,
+          describe: 'Path to the combined SHA256SUMS.txt produced by the release workflow',
+        })
+        .positional('version', {
+          type: 'string',
+          demandOption: true,
+          describe: 'Release tag (vX.Y.Z) or bare X.Y.Z',
+        }),
+  )
+  .strict()
+  .help()
+  .alias('help', 'h')
+  .version(false)
+  .parseAsync();
+
+const args: Args = {
+  sumsFile: argv.sumsFile as string,
+  version: argv.version as string,
+};
+
+// ──────────────────────────────────────────────────────────────────────
+
+function bareVersion(v: string): string {
+  return v.startsWith('v') ? v.slice(1) : v;
+}
+
+function parseSums(text: string): Map<string, string> {
+  // shasum -a 256 output: "<sha>  <filename>"
+  const out = new Map<string, string>();
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const m = trimmed.match(/^([0-9a-f]{64})\s+(.+)$/);
+    if (!m) throw new Error(`unparseable line in SHA256SUMS: ${line!}`);
+    out.set(m[2]!.trim(), m[1]!);
+  }
+  return out;
+}
+
+function pick(sums: Map<string, string>, name: string): string {
+  const v = sums.get(name);
+  if (!v) {
+    throw new Error(
+      `missing SHA256 for ${name}; SHA256SUMS contains: ${[...sums.keys()].join(', ')}`,
+    );
+  }
+  return v;
+}
+
+const tagVersion = bareVersion(args.version);
+const tag = `v${tagVersion}`;
+const sumsText = readFileSync(args.sumsFile, 'utf8');
+const sums = parseSums(sumsText);
+
+const darwinArm = pick(sums, 'fmrules-bun-darwin-arm64');
+const darwinX64 = pick(sums, 'fmrules-bun-darwin-x64');
+const linuxArm = pick(sums, 'fmrules-bun-linux-arm64');
+const linuxX64 = pick(sums, 'fmrules-bun-linux-x64');
+
+const baseUrl = `https://github.com/oomfiecity/fmrules/releases/download/${tag}`;
+
+const formula = `class Fmrules < Formula
+  desc "Declarative YAML authoring for Fastmail Email Rules"
+  homepage "https://github.com/oomfiecity/fmrules"
+  version "${tagVersion}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${baseUrl}/fmrules-bun-darwin-arm64"
+      sha256 "${darwinArm}"
+    else
+      url "${baseUrl}/fmrules-bun-darwin-x64"
+      sha256 "${darwinX64}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "${baseUrl}/fmrules-bun-linux-arm64"
+      sha256 "${linuxArm}"
+    else
+      url "${baseUrl}/fmrules-bun-linux-x64"
+      sha256 "${linuxX64}"
+    end
+  end
+
+  def install
+    bin.install Dir["*"].first => "fmrules"
+  end
+
+  test do
+    system "#{bin}/fmrules", "--help"
+  end
+end
+`;
+
+process.stdout.write(formula);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,12 @@ import { command as sync } from './commands/sync.ts';
 import { command as login } from './commands/login.ts';
 import { command as installBrowsers } from './commands/install-browsers.ts';
 
+// Stamped at build time by `scripts/build.ts` via Bun.build's `define`.
+// Falls back to `dev` when running source directly (`bun run src/cli.ts`),
+// so an unbuilt invocation never claims a real version.
+declare const __FMRULES_VERSION__: string | undefined;
+const VERSION = typeof __FMRULES_VERSION__ === 'string' ? __FMRULES_VERSION__ : 'dev';
+
 await yargs(hideBin(process.argv))
   .scriptName('fmrules')
   .usage('$0 <command> [options]')
@@ -25,5 +31,5 @@ await yargs(hideBin(process.argv))
   .strict()
   .help()
   .alias('help', 'h')
-  .version()
+  .version(VERSION)
   .parseAsync();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src/**/*", "tests/**/*", "meta/modules/**/*.ts"]
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*", "meta/modules/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Three release-pipeline fixes, one PR, three commits in order.

### Commit 1 — `fix: stamp --version at build time (closes #1)`

Replaces yargs's filesystem-based `.version()` autoload with a build-time literal injected via Bun.build's `define`. The autoload happens to work inside a Bun-compiled binary today by accident of how the VFS resolves paths from `process.argv[1]`; a bundler tweak or yargs upgrade could regress it silently.

After this commit:

- `bun run build && ./dist/fmrules --version` → reports `package.json` version exactly.
- `bun run src/cli.ts --version` → reports `dev`. Unambiguous about being unbuilt source.

### Commit 2 — `refactor: yargs in scripts/build.ts and scripts/release.ts (closes #6)`

`src/` uses yargs everywhere; the two scripts in `scripts/` used bare `Bun.argv[]` (build) and a hand-rolled `parseArgs` (release). Brings them in line with the rest of the repo. Behaviour identical; only the parser changes.

`scripts/release.ts` now uses yargs's `.conflicts()` for `--patch` / `--minor` / `--major` / positional `version`, and a `.check()` asserting at least one of them is supplied. yargs's built-in `--version` is disabled so it doesn't shadow the script's own `version` positional.

Verified locally:
- `bun run scripts/release.ts --help` → yargs-formatted help.
- `bun run scripts/release.ts 4.0.99 --dry-run` → preflight runs (then fails the branch check, as expected on a non-main branch).
- `bun run scripts/release.ts --patch --dry-run` → derives `4.0.3`.
- `bun run scripts/release.ts --patch --minor` → fails with conflict error.
- `bun run scripts/release.ts` (no args) → fails with the `.check()` error.

### Commit 3 — `ci: auto-bump homebrew formula on tag release (closes #3)`

New `bump-homebrew` job in `.github/workflows/release.yml`, gated on a real `vX.Y.Z` tag. Renders `Formula/fmrules.rb` via the new `scripts/render-homebrew-formula.ts` and pushes to `oomfiecity/homebrew-tap`'s `main` branch.

Verified locally — rendering against the live v4.0.2 SHA256SUMS produces a byte-identical formula to `oomfiecity/homebrew-tap/Formula/fmrules.rb`'s current content:

```
$ bun run scripts/render-homebrew-formula.ts /tmp/sums-v4.0.2.txt v4.0.2 > /tmp/rendered.rb
$ diff -u /tmp/live-formula.rb /tmp/rendered.rb
$ echo $?
0
```

### Prerequisites for #3 to take effect

Before the `bump-homebrew` job can succeed:

1. Create a fine-grained PAT on `oomfiecity/homebrew-tap` with `Contents: Read and write`.
2. Set it as `HOMEBREW_TAP_TOKEN` on `oomfiecity/fmrules`:
   ```
   gh secret set HOMEBREW_TAP_TOKEN --repo oomfiecity/fmrules
   ```

Without the secret the job fails 401 on the second checkout. The rest of the release pipeline is unaffected.

## Test plan

- [ ] `bun run ci` green (typecheck + 65 tests). ✓ locally.
- [ ] PR CI green.
- [ ] After merge + a real release (e.g. `bun release 4.0.3`):
  - [ ] Binary reports `4.0.3` not `unknown`.
  - [ ] `oomfiecity/homebrew-tap`'s main advances within a minute of the GitHub Release publishing.
  - [ ] Formula `version` line equals `4.0.3`; SHAs match the release assets.